### PR TITLE
ShibbolethAuthLime.php: ‘full_name’ now contains the first and last name

### DIFF
--- a/ShibbolethAuthLime.php
+++ b/ShibbolethAuthLime.php
@@ -95,7 +95,7 @@ class ShibbolethAuthLime extends AuthPluginBase
         $password = date('YmdHis').random_int(0, 1000);
         $oUser = new User();
         $oUser->users_name = $name;
-        $oUser->full_name = $name;
+        $oUser->full_name = $this->displayName;
         $oUser->email = $email;
         $oUser->parent_id = 1;
         $oUser->created = date('Y-m-d H:i:s');


### PR DESCRIPTION
‘full_name’ received the value of $this->displayName. Because $this->displayName contains the first and surename.